### PR TITLE
Fix autoRefreshTokens not updating session refresh token

### DIFF
--- a/packages/lucia-sveltekit/src/client.ts
+++ b/packages/lucia-sveltekit/src/client.ts
@@ -55,7 +55,7 @@ export const autoRefreshTokens = (
         session.update((val) => {
             if (!val.lucia) return val;
             val.lucia.access_token = accessToken;
-            val.lucia.refresh_token;
+            val.lucia.refresh_token = refreshToken;
             return val;
         });
     };


### PR DESCRIPTION
autoRefreshTokens is called after the access token expires and generates a new access and refresh token and saves it in a cookie, but it does not update the refresh token session store. When it runs again, the old refresh token is sent in the authorization header and causes handleRefreshRequest to throw REQUEST_UNAUTHORIZED since the refresh token is incorrect. 