### PR TITLE
update to 0.6.1

### DIFF
--- a/apps/example-github-oauth/package.json
+++ b/apps/example-github-oauth/package.json
@@ -37,6 +37,6 @@
 	"dependencies": {
 		"@lucia-sveltekit/adapter-prisma": "^0.3.0",
 		"@prisma/client": "^4.1.0",
-		"lucia-sveltekit": "^0.5.8"
+		"lucia-sveltekit": "^0.6.1"
 	}
 }

--- a/apps/example-username-password/package.json
+++ b/apps/example-username-password/package.json
@@ -35,6 +35,6 @@
 	"type": "module",
 	"dependencies": {
 		"@lucia-sveltekit/adapter-supabase": "^0.3.0",
-		"lucia-sveltekit": "^0.5.8"
+		"lucia-sveltekit": "^0.6.1"
 	}
 }

--- a/apps/example-username-password/src/routes/__layout.svelte
+++ b/apps/example-username-password/src/routes/__layout.svelte
@@ -5,7 +5,7 @@
 	import { session } from '$app/stores';
 </script>
 
-<Lucia {session}>
+<Lucia {session} on:error={(e) => {console.log(e)}}>
 	<slot />
 </Lucia>
 

--- a/apps/example-username-password/src/routes/index.svelte
+++ b/apps/example-username-password/src/routes/index.svelte
@@ -11,8 +11,6 @@
 </script>
 
 <script lang="ts">
-	import { dev } from '$app/env';
-
 	let error = '';
 	let username: string, password: string;
 

--- a/documentation/docs/05_server-apis/index.md
+++ b/documentation/docs/05_server-apis/index.md
@@ -361,7 +361,7 @@ const updateUserIdentifierToken: (
 Checks if the request was made by an authenticated user using the authorization header. The access token should be sent as a bearer token inside the authorization header. For GET and POST requests.
 
 ```ts
-const validateRequest: (request: Request) => Promise<User<UserData>>;
+const validateRequest: (request: Request) => Promise<Session<UserData>>;
 ```
 
 #### Parameters
@@ -372,9 +372,9 @@ const validateRequest: (request: Request) => Promise<User<UserData>>;
 
 #### Returns
 
-| name | type                           | description |
-| ---- | ------------------------------ | ----------- |
-|      | [User](/references/types#user) |             |
+| name | type                                 | description |
+| ---- | ------------------------------------ | ----------- |
+|      | [Session](/references/types#session) |             |
 
 #### Errors
 
@@ -387,7 +387,7 @@ const validateRequest: (request: Request) => Promise<User<UserData>>;
 Checks if the request was made by an authenticated user using cookies. **Do NOT use this for POST or PUT requests as it is vulnerable to CSRF attacks**, and it will throw an error if it is not a GET request for preventive measures.
 
 ```ts
-const validateRequest: (request: Request) => Promise<User<UserData>>;
+const validateRequest: (request: Request) => Promise<Session<UserData>>;
 ```
 
 #### Parameters
@@ -398,9 +398,9 @@ const validateRequest: (request: Request) => Promise<User<UserData>>;
 
 #### Returns
 
-| name | type                           | description |
-| ---- | ------------------------------ | ----------- |
-|      | [User](/references/types#user) |             |
+| name | type                                 | description |
+| ---- | ------------------------------------ | ----------- |
+|      | [Session](/references/types#session) |             |
 
 #### Errors
 

--- a/documentation/docs/09_changelog/index.md
+++ b/documentation/docs/09_changelog/index.md
@@ -1,3 +1,17 @@
+## 0.6.1
+
+Aug 14, 2022
+
+-   `Session.cookie` returned by `validateRequest` and `validateRequestByCookie` are the values of existing cookies instead of new cookies
+
+## 0.6.0
+
+Aug. 14, 2022
+
+-   Fixed issues with `Lucia.svelte` wrapper 
+-   `validateRequest` and `validateRequestByCookie` returns a `Session` instead of `User`
+
+
 ## 0.5.8
 
 Aug. 4, 2022

--- a/packages/lucia-sveltekit/package.json
+++ b/packages/lucia-sveltekit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucia-sveltekit",
-    "version": "0.5.9",
+    "version": "0.6.1",
     "description": "A simple authentication library for SvelteKit",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/lucia-sveltekit/src/Lucia.svelte
+++ b/packages/lucia-sveltekit/src/Lucia.svelte
@@ -11,7 +11,8 @@
     let interval: NodeJS.Timer;
 
     onMount(() => {
-        interval = setInterval(() => {
+        let isRefreshInProgress = false;
+        interval = setInterval(async () => {
             try {
                 if (
                     !$session.lucia?.access_token ||
@@ -20,6 +21,7 @@
                     return;
                 const tokenData = getJwtPayload($session.lucia?.access_token);
                 const currentTime = new Date().getTime();
+                if (!isRefreshInProgress) return;
                 if (!tokenData) {
                     throw new LuciaError("AUTH_INVALID_ACCESS_TOKEN");
                 }
@@ -27,15 +29,17 @@
                     throw new LuciaError("AUTH_INVALID_ACCESS_TOKEN");
                 }
                 if (currentTime + 60 * 1000 > tokenData.exp * 1000) {
-                    refresh($session.lucia?.refresh_token);
+                    isRefreshInProgress = true;
+                    await refresh($session.lucia?.refresh_token);
                 }
             } catch (e) {
-                const error = e as Error;
+                const error = e as LuciaError;
                 console.error(error);
                 clearInterval(interval);
                 return disptach("error", error.message);
             }
-        }, 10000);
+            isRefreshInProgress = false;
+        }, 1000);
     });
 
     onDestroy(() => {

--- a/packages/lucia-sveltekit/src/auth/request.ts
+++ b/packages/lucia-sveltekit/src/auth/request.ts
@@ -2,38 +2,72 @@ import { LuciaError } from "../utils/error.js";
 import type { Context } from "./index.js";
 import cookie from "cookie";
 import type { User } from "../types.js";
-import { AccessToken, FingerprintToken } from "../utils/token.js";
+import {
+    AccessToken,
+    FingerprintToken,
+    EncryptedRefreshToken,
+    RefreshToken,
+} from "../utils/token.js";
 import { Error } from "../index.js";
 
 export type ValidateRequest<UserData extends {}> = (
     request: Request
-) => Promise<User<UserData>>;
+) => Promise<{
+    user: User<UserData>;
+    access_token: AccessToken<UserData>;
+    refresh_token: RefreshToken;
+    fingerprint_token: FingerprintToken;
+    cookies: string[];
+}>;
 export const validateRequestFunction = <UserData extends {}>(
     context: Context
 ) => {
     const validateRequest: ValidateRequest<UserData> = async (request) => {
-        const authorizationHeader = request.headers.get("Authorization") || "";
+        const clonedReq = request.clone();
+        const authorizationHeader =
+            clonedReq.headers.get("Authorization") || "";
         const [tokenType, token] = authorizationHeader.split(" ");
         if (!tokenType || !token)
             throw new LuciaError("AUTH_INVALID_ACCESS_TOKEN");
         if (tokenType !== "Bearer")
             throw new LuciaError("AUTH_INVALID_ACCESS_TOKEN");
         if (!token) throw new LuciaError("AUTH_INVALID_ACCESS_TOKEN");
-        const cookies = cookie.parse(request.headers.get("cookie") || "");
+        const cookies = cookie.parse(clonedReq.headers.get("cookie") || "");
         const fingerprintToken = new FingerprintToken(
             cookies.fingerprint_token,
             context
         );
         const accessToken = new AccessToken<UserData>(token, context);
+        const encryptedRefreshToken = new EncryptedRefreshToken(
+            cookies.encrypt_refresh_token,
+            context
+        );
+        const refreshToken = encryptedRefreshToken.decrypt();
         const user = await accessToken.user(fingerprintToken.value);
-        return user;
+        return {
+            user,
+            access_token: accessToken,
+            refresh_token: refreshToken,
+            fingerprint_token: fingerprintToken,
+            cookies: [
+                cookies.access_token,
+                cookies.encrypt_refresh_token,
+                cookies.fingerprint_token,
+            ],
+        };
     };
     return validateRequest;
 };
 
 export type ValidateRequestByCookie<UserData extends {}> = (
     request: Request
-) => Promise<User<UserData>>;
+) => Promise<{
+    user: User<UserData>;
+    access_token: AccessToken<UserData>;
+    refresh_token: RefreshToken;
+    fingerprint_token: FingerprintToken;
+    cookies: string[];
+}>;
 
 export const validateRequestByCookieFunction = <UserData extends {}>(
     context: Context
@@ -41,10 +75,10 @@ export const validateRequestByCookieFunction = <UserData extends {}>(
     const validateRequestByCookie: ValidateRequest<UserData> = async (
         request
     ) => {
-        const method = request.method;
-        if (method !== "GET")
-            throw new Error("AUTH_INVALID_REQUEST");
-        const cookies = cookie.parse(request.headers.get("cookie") || "");
+        const clonedReq = request.clone();
+        const method = clonedReq.method;
+        if (method !== "GET") throw new Error("AUTH_INVALID_REQUEST");
+        const cookies = cookie.parse(clonedReq.headers.get("cookie") || "");
         const fingerprintToken = new FingerprintToken(
             cookies.fingerprint_token,
             context
@@ -54,7 +88,22 @@ export const validateRequestByCookieFunction = <UserData extends {}>(
             context
         );
         const user = await accessToken.user(fingerprintToken.value);
-        return user;
+        const encryptedRefreshToken = new EncryptedRefreshToken(
+            cookies.encrypt_refresh_token,
+            context
+        );
+        const refreshToken = encryptedRefreshToken.decrypt();
+        return {
+            user,
+            access_token: accessToken,
+            refresh_token: refreshToken,
+            fingerprint_token: fingerprintToken,
+            cookies: [
+                cookies.access_token,
+                cookies.encrypt_refresh_token,
+                cookies.fingerprint_token,
+            ],
+        };
     };
     return validateRequestByCookie;
 };

--- a/packages/lucia-sveltekit/src/auth/session.ts
+++ b/packages/lucia-sveltekit/src/auth/session.ts
@@ -20,7 +20,6 @@ export type CreateUserSession<UserData extends {}> = (
     user: User<UserData>;
     access_token: AccessToken<UserData>;
     refresh_token: RefreshToken;
-    encrypted_refresh_token: EncryptedRefreshToken;
     fingerprint_token: FingerprintToken;
     cookies: string[];
 }>;
@@ -58,7 +57,6 @@ export const createUserSessionFunction = <UserData extends {}>(
             access_token: accessToken,
             refresh_token: refreshToken,
             fingerprint_token: fingerprintToken,
-            encrypted_refresh_token: encryptedRefreshToken,
             cookies: [
                 accessTokenCookie,
                 encryptedRefreshTokenCookie,

--- a/test-apps/username-password/package.json
+++ b/test-apps/username-password/package.json
@@ -39,6 +39,6 @@
 		"bcryptjs": "^2.4.3",
 		"cookie": "^0.5.0",
 		"jsonwebtoken": "^8.5.1",
-		"lucia-sveltekit": "^0.5.8"
+		"lucia-sveltekit": "^0.6.1"
 	}
 }


### PR DESCRIPTION
-   `Session.cookie` returned by `validateRequest` and `validateRequestByCookie` are the values of existing cookies instead of new cookies
-   Fixed issues with silent refresh in `Lucia.svelte` wrapper 
-   `validateRequest` and `validateRequestByCookie` returns a `Session` instead of `User`
-   Tested silent refresh in `Lucia.svelte` overnight