### PR TITLE
update to 0.6.2

### DIFF
--- a/apps/documentation/src/routes/[...doc].svelte
+++ b/apps/documentation/src/routes/[...doc].svelte
@@ -103,4 +103,7 @@
 	:global(.markdown .breaking) {
 		@apply text-red-500 font-medium;
 	}
+	:global(.markdown .fix) {
+		@apply text-blue-500 font-medium;
+	}
 </style>

--- a/apps/documentation/src/routes/api/docs/[...doc].ts
+++ b/apps/documentation/src/routes/api/docs/[...doc].ts
@@ -45,6 +45,10 @@ export const get: RequestHandler = async ({ params }) => {
 			'[Breaking]',
 			'<span class="breaking">[Breaking]</span>'
 		);
+		element.innerHTML = element.innerHTML.replaceAll(
+			'[Fix]',
+			'<span class="fix">[Fix]</span>'
+		);
 	});
 	html = document.toString()
 	return {

--- a/apps/example-github-oauth/package.json
+++ b/apps/example-github-oauth/package.json
@@ -37,6 +37,6 @@
 	"dependencies": {
 		"@lucia-sveltekit/adapter-prisma": "^0.3.0",
 		"@prisma/client": "^4.1.0",
-		"lucia-sveltekit": "^0.6.1"
+		"lucia-sveltekit": "^0.6.2"
 	}
 }

--- a/apps/example-username-password/package.json
+++ b/apps/example-username-password/package.json
@@ -35,6 +35,6 @@
 	"type": "module",
 	"dependencies": {
 		"@lucia-sveltekit/adapter-supabase": "^0.3.0",
-		"lucia-sveltekit": "^0.6.1"
+		"lucia-sveltekit": "^0.6.2"
 	}
 }

--- a/documentation/docs/09_changelog/index.md
+++ b/documentation/docs/09_changelog/index.md
@@ -1,3 +1,10 @@
+## 0.6.2
+
+Aug 15, 2022
+
+-   [Breaking] All tokens issued before this update is invalid
+-   [Fix] `validateRequest` and `validateRequestByCookie` rejects refresh tokens
+
 ## 0.6.1
 
 Aug 14, 2022
@@ -34,7 +41,7 @@ Aug. 3, 2022
 
 Aug. 3, 2022
 
--   [fix] `validateRequest` now checks for the authorization header as stated in the headers instead of cookies
+-   [Fix] `validateRequest` now checks for the authorization header as stated in the headers instead of cookies
 -   New `validateRequestByCookie` to validate requests using cookies - for GET requests
 
 ## 0.5.0
@@ -49,7 +56,7 @@ Jul. 30, 2022
 
 Jul. 28, 2022
 
--   [fix] Fixed `adapterGetUpdateData()`
+-   [Fix] Fixed `adapterGetUpdateData()`
 
 ## 0.4.0
 

--- a/packages/lucia-sveltekit/package.json
+++ b/packages/lucia-sveltekit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucia-sveltekit",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "description": "A simple authentication library for SvelteKit",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/lucia-sveltekit/src/types.ts
+++ b/packages/lucia-sveltekit/src/types.ts
@@ -36,10 +36,11 @@ export type User<UserData extends {}> = UserData & {
     user_id: string;
 };
 
-export interface Session {
+export interface TokenData {
     fingerprint_hash: string;
     iat: number;
     exp: number;
+    role: "access_token" | "refresh_token"
 }
 
 export type DatabaseUser<UserData> = {

--- a/packages/lucia-sveltekit/src/utils/auth.ts
+++ b/packages/lucia-sveltekit/src/utils/auth.ts
@@ -14,6 +14,7 @@ export const createAccessToken = async <UserData extends {}>(
         {
             ...user,
             fingerprint_hash: hashedFingerprint,
+            role: "access_token",
         },
         context.secret,
         {
@@ -33,6 +34,7 @@ export const createRefreshToken = async (
         {
             user_id: userId,
             fingerprint_hash: hashedFingerprint,
+            role: "refresh_token",
         },
         context.secret,
         {

--- a/test-apps/username-password/package.json
+++ b/test-apps/username-password/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "example-username-password",
+	"name": "username-password",
 	"version": "0.0.1",
 	"scripts": {
 		"dev": "vite dev",
@@ -39,6 +39,6 @@
 		"bcryptjs": "^2.4.3",
 		"cookie": "^0.5.0",
 		"jsonwebtoken": "^8.5.1",
-		"lucia-sveltekit": "^0.6.1"
+		"lucia-sveltekit": "workspace:*"
 	}
 }


### PR DESCRIPTION
-   [Breaking] All tokens issued before this update is invalid
-   [Fix] `validateRequest` and `validateRequestByCookie` rejects refresh tokens