### PR TITLE
Update NPM Packages on Main Branch Push

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -69,24 +69,26 @@ jobs:
           dir=$(pwd)
           npm i -g pnpm
           pkg_string="${{ needs.check_pkgs.outputs.packages }}"
-
+          build_cmd="pnpm install --no-frozen-lockfile && pnpm build && cd dist && pnpm publish --no-git-checks --access public && cd $dir"
+          
           if [[ $pkg_string == *"lucia-sveltekit"* ]]; then
-            cd packages/lucia-sveltekit && pnpm install --no-frozen-lockfile && pnpm build && cd dist && pnpm publish --no-git-checks --access public && cd $dir
+            cd packages/lucia-sveltekit && eval "$build_cmd"
           fi
           if [[ $pkg_string == *"adapter-couchdb"* ]]; then
-            cd packages/adapter-couchdb && pnpm install --no-frozen-lockfile && pnpm build && cd dist && pnpm publish --no-git-checks --access public && cd $dir
+            cd packages/adapter-couchdb && eval "$build_cmd"
           fi
           if [[ $pkg_string == *"adapter-mongoose"* ]]; then
-            cd packages/adapter-mongoose && pnpm install --no-frozen-lockfile && pnpm build && cd dist && pnpm publish --no-git-checks --access public && cd $dir
+            cd packages/adapter-mongoose && eval "$build_cmd"
           fi
           if [[ $pkg_string == *"adapter-prisma"* ]]; then
-            cd packages/adapter-prisma && pnpm install --no-frozen-lockfile && pnpm build && cd dist && pnpm publish --no-git-checks --access public && cd $dir
+            cd packages/adapter-prisma && eval "$build_cmd"
           fi
           if [[ $pkg_string == *"adapter-supabase"* ]]; then
-            cd packages/adapter-supabase && pnpm install --no-frozen-lockfile && pnpm build && cd dist && pnpm publish --no-git-checks --access public && cd $dir
+            cd packages/adapter-supabase && eval "$build_cmd"
           fi
           if [[ $pkg_string == *"adapter-test"* ]]; then
-            cd packages/adapter-test && pnpm install --no-frozen-lockfile && pnpm build && cd dist && pnpm publish --no-git-checks --access public && cd $dir
+            cd packages/adapter-test && eval "$build_cmd"
           fi
+
         env:
           NODE_AUTH_TOKEN: ${{secrets.PNPM_AUTH_TOKEN}}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,92 @@
+name: '🚀 publish'
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  check_pkgs:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      packages: ${{ steps.runscript.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - id: runscript
+        run: |
+          #check last commit
+          output=$(git diff --name-only HEAD^ HEAD)
+          pkg_array=()
+          declare -A uniq_pkg_array
+
+          #loop through git diff for changes
+          for line in ${output[@]}; do
+              if [[ $line == packages/lucia-sveltekit* ]];
+              then
+                  pkg_array+=("lucia-sveltekit")
+              elif [[ $line == packages/adapter-couchdb* ]];
+              then
+                  pkg_array+=("adapter-couchdb")
+              elif [[ $line == packages/adapter-mongoose* ]];
+              then
+                  pkg_array+=("adapter-mongoose")
+              elif [[ $line == packages/adapter-prisma* ]];
+              then
+                  pkg_array+=("adapter-prisma")
+              elif [[ $line == packages/adapter-supabase* ]];
+              then
+                  pkg_array+=("adapter-supabase")
+              elif [[ $line == packages/adapter-test* ]];
+              then
+                  pkg_array+=("adapter-test")
+              fi
+          done
+
+          for pkg in "${pkg_array[@]}"; do
+            uniq_pkg_array[$pkg]=0
+          done
+
+          #set output vars
+          echo "::set-output name=matrix::${!uniq_pkg_array[@]}"
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: check_pkgs
+    if: ${{ needs.check_pkgs.outputs.packages != '' && needs.check_pkgs.outputs.packages != '[]' }}
+    steps:
+      - name: 📚 checkout
+        uses: actions/checkout@v3
+      - name: 🟢 node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org
+      - name: publish
+        run: |
+          dir=$(pwd)
+          npm i -g pnpm
+          pkg_string="${{ needs.check_pkgs.outputs.packages }}"
+
+          if [[ $pkg_string == *"lucia-sveltekit"* ]]; then
+            cd packages/lucia-sveltekit && pnpm install --no-frozen-lockfile && pnpm build && cd dist && pnpm publish --no-git-checks --access public && cd $dir
+          fi
+          if [[ $pkg_string == *"adapter-couchdb"* ]]; then
+            cd packages/adapter-couchdb && pnpm install --no-frozen-lockfile && pnpm build && cd dist && pnpm publish --no-git-checks --access public && cd $dir
+          fi
+          if [[ $pkg_string == *"adapter-mongoose"* ]]; then
+            cd packages/adapter-mongoose && pnpm install --no-frozen-lockfile && pnpm build && cd dist && pnpm publish --no-git-checks --access public && cd $dir
+          fi
+          if [[ $pkg_string == *"adapter-prisma"* ]]; then
+            cd packages/adapter-prisma && pnpm install --no-frozen-lockfile && pnpm build && cd dist && pnpm publish --no-git-checks --access public && cd $dir
+          fi
+          if [[ $pkg_string == *"adapter-supabase"* ]]; then
+            cd packages/adapter-supabase && pnpm install --no-frozen-lockfile && pnpm build && cd dist && pnpm publish --no-git-checks --access public && cd $dir
+          fi
+          if [[ $pkg_string == *"adapter-test"* ]]; then
+            cd packages/adapter-test && pnpm install --no-frozen-lockfile && pnpm build && cd dist && pnpm publish --no-git-checks --access public && cd $dir
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.PNPM_AUTH_TOKEN}}


### PR DESCRIPTION
Looks for changes in package/* dirs and auto publishes to NPM when changes detected in last commit using straightforward bash. Should be merged after package type defs are fixed for the adapters. Currently set up to auto bump minor version on change - this can be easily adjusted. 'PNPM_AUTH_TOKEN' secret must be set in Github > Repo > Settings and NPM > Repo > Settings

closes #10 