### PR TITLE
0.8.8

### DIFF
--- a/documentation/docs/10_changelog/index.md
+++ b/documentation/docs/10_changelog/index.md
@@ -1,3 +1,9 @@
+## 0.8.8
+
+Sep. 24, 2022
+
+-   [Fix] Fixed issue where `getSession()` (client) was not getting populated on newer versions of SvelteKit and large page data
+
 ## 0.8.7
 
 Sep. 24, 2022

--- a/packages/lucia-sveltekit/package.json
+++ b/packages/lucia-sveltekit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucia-sveltekit",
-    "version": "0.8.7",
+    "version": "0.8.8",
     "description": "A simple authentication library for SvelteKit",
     "main": "index.js",
     "types": "index.d.ts",

--- a/packages/lucia-sveltekit/src/auth/hooks.ts
+++ b/packages/lucia-sveltekit/src/auth/hooks.ts
@@ -72,14 +72,14 @@ export const handleHooksFunction = (context: Context) => {
                 transformPageChunk: ({ html }) => {
                     // finds hydrate.data value from parameter of start()
                     const pageDataFunctionRegex = new RegExp(
-                        /(<script type="module" data-sveltekit-hydrate=".*?">)[\s\S]*start\(\{[\s\S]*?hydrate:[\s\S]*?data: \((function\(.*?\){return.*)\)[\s\S]*?\}\);\s*<\/script>/gm
+                        /(<script type="module" data-sveltekit-hydrate=".*?">)[\s\S]*start\(\s*\{[\s\S]*?hydrate:[\s\S]*?data:\s*\(\s*(function\([\s\S]*?\)\s*{\s*return[\s\S]*)\),\s*form:[\s\S]*?\}\);\s*<\/script>/gm
                     );
                     const matches = pageDataFunctionRegex.exec(html);
                     if (!matches) return html;
                     html = html.replace(
                         matches[1],
                         `${matches[1]}
-                    window._lucia_page_data = ${matches[2]}
+                    window._lucia_page_data = ${matches[2]};
                     `
                     );
                     return html;

--- a/test-apps/username-password/package.json
+++ b/test-apps/username-password/package.json
@@ -34,8 +34,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@lucia-sveltekit/adapter-supabase": "workspace:*",
-		"lucia-sveltekit": "workspace:*",
-		"@lucia-sveltekit/adapter-prisma": "workspace:*"
+		"@lucia-sveltekit/adapter-supabase": "^0.3.3",
+		"lucia-sveltekit": "workspace:*"
 	}
 }


### PR DESCRIPTION
-   [Fix] Fixed issue where `getSession()` (client) was not getting populated on newer versions of SvelteKit and large page data
