### PR TITLE
Fixes grammatical error on homepage.

### DIFF
--- a/documentation/src/pages/index.astro
+++ b/documentation/src/pages/index.astro
@@ -10,7 +10,7 @@ import MainLayout from "../layouts/MainLayout.astro";
         </p>
         <p class="my-8">
             Barebones by design, it makes managaing users and sessions simple.
-            It it easy to use and understand, yet, providing the flexibility
+            It it easy to use and understand while providing the flexibility
             that many other libraries lack. It's the authentication solution
             that works with you and your app, not the other way around. Get
             started by reading the <a href="/learn/start-here/introduction" class="text-main hover:underline"


### PR DESCRIPTION
You could also say "It is easy to use and understand, yet provides* the flexibility...". You most certainly don't need 2 comma's around "yet" and if you want to keep "providing the flexibility" this is probably your best bet.