### PR TITLE
Fix contribute doc link

### DIFF
--- a/documentation/src/layouts/DocumentLayout.astro
+++ b/documentation/src/layouts/DocumentLayout.astro
@@ -8,6 +8,10 @@ type Props = MarkdownLayoutProps<{
     order: number;
 }>;
 const { frontmatter, headings } = Astro.props;
+
+//FIXME: problem: on ASTRO DEV url.pathname not having trailing slash, on ASTRO PREVIEW it has and breaking link.
+//INFO: temporary hotfix
+const contributePageUrl = Astro.url.pathname.endsWith("/") ? Astro.url.pathname.slice(0, -1) : Astro.url.pathname
 ---
 
 <BaseLayout title={frontmatter.title}>
@@ -18,7 +22,7 @@ const { frontmatter, headings } = Astro.props;
         </section>
         <div class="mt-8">
             <a
-                href={`https://github.com/pilcrowOnPaper/lucia-sveltekit/blob/main/documentation/src/pages${Astro.url.pathname}.md`}
+                href={`https://github.com/pilcrowOnPaper/lucia-sveltekit/blob/main/documentation/src/pages${contributePageUrl}.md`}
                 class="text-main hover:underline cursor-pointer;"
                 >Contribute to this page</a
             >

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
-packages: 
+packages:
   - "packages/*/dist"
   - "packages/**"
   - "apps/**"
   - "test-apps/**"
+  - "documentation/**"


### PR DESCRIPTION
Two commits:

1. Because `pnpm install` was not creating `node_modules` in documentation folder.
2. Hotfix for broken links in docs for contribution github.

For point 2:
- This solving issue #134
- Idea for variable was from PR #138
- It's not perfect solution, but working well for all scenarios for now.
- The main rootcouse is in astro implementation itself probably. But I was not able to spend more time to dig into.
- In past there was similar issue but with different method: https://github.com/withastro/astro/issues/4252
- When looking for proper fix, comment my hotfix, replace variable in path to `Astro.url.pathname` and compare contribution links in docs pages in `astro dev` with `astro build & astro preview`

Have hope this is good PR for you ;)